### PR TITLE
Fix path issue for Node 6

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ module.exports = function(input) {
   const callback = this.async();
   // mock async step 2 - offer css loader a "fake" callback
   this.async = () => (err, content) => {
-    const cssmodules = this.exec(content);
+    const cssmodules = this.exec(content, this.resource);
     const requestedResource = this.resourcePath;
 
     const cssModuleInterfaceFilename = filenameToTypingsFilename(requestedResource);


### PR DESCRIPTION
As Node 6 expects a path to be a string, not passing the path as a second argument  on `this.exec` breaks the loader. 
Adding `this.resource` fixes the issue.

ptal @timse