### PR TITLE
add css-loader as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "css modules webpack typings"
   ],
   "dependencies": {
+    "css-loader": ">=0.23.1",
     "graceful-fs": "4.1.4",
     "loader-utils": "0.2.16"
   },
@@ -40,9 +41,6 @@
     "ts-loader": "^0.8.2",
     "typescript": "^1.8.10",
     "webpack": "^1.13.2"
-  },
-  "peerDependencies": {
-    "css-loader": ">=0.23.1"
   },
   "repository": {
     "type": "git",

--- a/test/example-camelcase-namedexport.css.d.ts
+++ b/test/example-camelcase-namedexport.css.d.ts
@@ -1,0 +1,2 @@
+export const foo: string;
+export const barBaz: string;

--- a/test/example-camelcase.css.d.ts
+++ b/test/example-camelcase.css.d.ts
@@ -1,0 +1,8 @@
+export interface IExampleCamelcaseCss {
+  'foo': string;
+  'bar-baz': string;
+  'barBaz': string;
+}
+declare const styles: IExampleCamelcaseCss;
+
+export default styles;

--- a/test/example-namedexport.css.d.ts
+++ b/test/example-namedexport.css.d.ts
@@ -1,0 +1,1 @@
+export const foo: string;


### PR DESCRIPTION
- as of npm 3 it seems there is no benefit in not specifying the dependency of css-loader directly
- also it makes tests run out of the box, as they require css-loader anyways