### PR TITLE
early return and warn if modules option not set

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "css modules webpack typings"
   ],
   "dependencies": {
-    "graceful-fs": "4.1.4"
+    "graceful-fs": "4.1.4",
+    "loader-utils": "0.2.16"
   },
   "devDependencies": {
     "babel-cli": "6.10.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,30 @@
 import cssLoader from 'css-loader';
 import cssLocalsLoader from 'css-loader/locals';
+import loaderUtils from 'loader-utils';
 import {
   generateInterface,
   filenameToTypingsFilename,
 } from './cssModuleToInterface';
 import * as persist from './persist';
 
+function delegateToCssLoader(ctx, input, callback) {
+  ctx.async = () => callback;
+  cssLoader.call(ctx, input);
+}
+
 module.exports = function(input) {
   if(this.cacheable) this.cacheable();
 
   // mock async step 1 - css loader is async, we need to intercept this so we get async ourselves
   const callback = this.async();
+
+  const query = loaderUtils.parseQuery(this.query);
+  const moduleMode = query.modules || query.module;
+  if (!moduleMode) {
+    console.warn('Typings for CSS-Modules: option `modules` is not active - skipping extraction work...');
+    return delegateToCssLoader(ctx, input, callback);
+  }
+
   // mock async step 2 - offer css loader a "fake" callback
   this.async = () => (err, content) => {
     const cssmodules = this.exec(content, this.resource);
@@ -20,8 +34,7 @@ module.exports = function(input) {
     const cssModuleInterface = generateInterface(cssmodules, requestedResource);
     persist.writeToFileIfChanged(cssModuleInterfaceFilename, cssModuleInterface);
     // mock async step 3 - make `async` return the actual callback again before calling the 'real' css-loader
-    this.async = () => callback;
-    cssLoader.call(this, input);
+    delegateToCssLoader(this, input, callback);
   };
   cssLocalsLoader.call(this, input);
 }


### PR DESCRIPTION
if modules option is not set, css-loader will not produce any css-modules thus rendering this loader useless