### PR TITLE
Use platform specific endline character

### DIFF
--- a/src/cssModuleToInterface.js
+++ b/src/cssModuleToInterface.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import os from 'os';
 
 const filenameToInterfaceName = (filename) => {
   return path.basename(filename)
@@ -9,13 +10,13 @@ const filenameToInterfaceName = (filename) => {
 const cssModuleToTypescriptInterfaceProperties = (cssModuleKeys, indent = '  ') => {
   return cssModuleKeys
     .map((key) => `${indent}'${key}': string;`)
-    .join('\n');
+    .join(os.EOL);
 };
 
 const cssModuleToNamedExports = (cssModuleKeys) => {
   return cssModuleKeys
     .map((key) => `export const ${key}: string;`)
-    .join('\n');
+    .join(os.EOL);
 };
 
 const allWordsRegexp = /^\w+$/i;


### PR DESCRIPTION
This change will help windows users who use the autocrlf=true setting in git. Each time the .d.ts files are regen'd they show up as changed due to the newline character difference.

I'm on my Windows machine now, so I wasn't able to run the tests. I'm not sure if that happens as part of the PR here, but maybe you could help me run them if not?