### PR TITLE
FIX: changes regex to remove false-positives from webpack2 builds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ module.exports = function(input) {
     const filename = this.resourcePath;
     const cssModuleInterfaceFilename = filenameToTypingsFilename(filename);
 
-    const keyRegex = /"([^"]+)":/g;
+    const keyRegex = /"([^\\"]+)":/g;
     let match;
     const cssModuleKeys = [];
 


### PR DESCRIPTION
First off: Really cool package!
I just tried it out with my webpack2-setup, worked almost out of the box. There was just one thing wrong, the generated `css.d.ts` contained the options I gave the loader:
![screen shot 2017-02-16 at 15 04 47](https://cloud.githubusercontent.com/assets/2116347/23024188/47402b94-f459-11e6-8861-f3b8609cf4b2.png)

This was due to the fact, that the options for loaders are given like this in webpack2:
```
exports.css = {
    test: /\.css$/,
    use: ExtractTextPlugin.extract({
        fallback: 'style-loader',
        use: [
            {
                loader: 'typings-for-css-modules-loader',
                options: {
                    modules: true,
                    nameExport: true,
                    camelCase: true
                }
            },
            {
                loader: 'postcss-loader',
                options: {
                    plugins: postcssPlugin
                }
            }
        ]
    })
};
```

So when I checked what the content looked like where the regex was applied, it looked like this:
<img width="663" alt="screen shot 2017-02-16 at 14 56 24" src="https://cloud.githubusercontent.com/assets/2116347/23024226/885e5150-f459-11e6-9291-9e9cf0b66658.png">

To fix it, I added `\\` into the forbidden characters:
<img width="661" alt="screen shot 2017-02-16 at 14 57 07" src="https://cloud.githubusercontent.com/assets/2116347/23024268/b981cc44-f459-11e6-9edb-57a12126e9c9.png">

I tested the fix on my local setup, where it solved the problem. `\` is not a valid css-classname, so it should be impossible that this fix should break something.