### PR TITLE
Allow generation of the interface and named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ export interface IExampleCss {
   'foo': string;
   'bar-baz': string;
 }
-declare const styles: IExampleCss;
 
-export default styles;
+declare const locals: IExampleCss;
 ```
 
 A cleaner way is to expose all classes as named exports, this can be done if you enable the `namedExport`-option.
@@ -56,6 +55,37 @@ export const barBaz: string;
 ```
 
  `css-loader` exports mappings to `exports.locals` which is incompatible with the `namedExport`-option unless paired with `extract-text-webpack-plugin` or `style-loader`. They move the exported properties from `exports.locals` to `exports` making them reuired for `namedExport` to work, and `namedExport` required for them to work. *Always combine usage of `extract-text-webpack-plugin` or `style-loader` with the `namedExport`-option.*
+
+### `interface`-option
+
+Specify the interface option along with the namedExport option to also generate an interface. This option is useful if you need to use both
+the named exports (for style-loader compatibility), but also have a reason to use the interface (for instance, to refer to the type from TypeScript).
+
+with:
+```js
+  { test: /\.css$/, loader: 'typings-for-css-modules?modules&namedExport&interface&camelCase' }
+```
+using the following css:
+```css
+.foo {
+  color: white;
+}
+
+.bar-baz {
+  color: green;
+}
+```
+
+will generate the following typings file:
+```ts
+export interface IExampleNamedExportAndInterfaceCss {
+  'foo': string;
+  'barBaz': string;
+}
+
+export const foo: string;
+export const barBaz: string;
+```
 
 ### `silent`-option
 To silence the loader because you get annoyed by its warnings or for other reasons, you can simply pass the "silent" query to the loader and it will shut up.

--- a/src/cssModuleToInterface.js
+++ b/src/cssModuleToInterface.js
@@ -52,9 +52,9 @@ export const locals: ${interfaceName};
 `);
 };
 
-export const generateCombinedInterfaceAndNamedExports = (cssModuleKeys, cleanedDefinitions, filename, indent) => {
+export const generateCombinedInterfaceAndNamedExports = (cleanedDefinitions, filename, indent) => {
   const interfaceName = filenameToInterfaceName(filename);
-  const interfaceProperties = cssModuleToTypescriptInterfaceProperties(cssModuleKeys, indent);
+  const interfaceProperties = cssModuleToTypescriptInterfaceProperties(cleanedDefinitions, indent);
   return (
     `export interface ${interfaceName} {
 ${interfaceProperties}

--- a/src/cssModuleToInterface.js
+++ b/src/cssModuleToInterface.js
@@ -51,3 +51,15 @@ ${interfaceProperties}
 export const locals: ${interfaceName};
 `);
 };
+
+export const generateCombinedInterfaceAndNamedExports = (cssModuleKeys, cleanedDefinitions, filename, indent) => {
+  const interfaceName = filenameToInterfaceName(filename);
+  const interfaceProperties = cssModuleToTypescriptInterfaceProperties(cssModuleKeys, indent);
+  return (
+    `export interface ${interfaceName} {
+${interfaceProperties}
+}
+
+${cssModuleToNamedExports(cleanedDefinitions)}
+`);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ ${skippedDefinitions.map(sd => ` - "${sd}"`).join('\n').red}
 
     if (query.namedExport && query.interface) {
       logSkippedDefWarning();
-      cssModuleDefinition = generateCombinedInterfaceAndNamedExports(cssModuleKeys, cleanedDefinitions, filename);
+      cssModuleDefinition = generateCombinedInterfaceAndNamedExports(cleanedDefinitions, filename);
     } else if (!query.namedExport) {
       cssModuleDefinition = generateGenericExportInterface(cssModuleKeys, filename);
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import 'colour';
 import {
   filterNonWordClasses,
   generateNamedExports,
+  generateCombinedInterfaceAndNamedExports,
   generateGenericExportInterface,
   filenameToTypingsFilename,
 } from './cssModuleToInterface';
@@ -51,16 +52,25 @@ module.exports = function(input) {
     }
 
     let cssModuleDefinition;
-    if (!query.namedExport) {
-      cssModuleDefinition = generateGenericExportInterface(cssModuleKeys, filename);
-    } else {
-      const [cleanedDefinitions, skippedDefinitions,] = filterNonWordClasses(cssModuleKeys);
+    const [cleanedDefinitions, skippedDefinitions,] = filterNonWordClasses(cssModuleKeys);
+
+    const logSkippedDefWarning = () => {
       if (skippedDefinitions.length > 0 && !query.camelCase) {
         logger('warn', `Typings for CSS-Modules: option 'namedExport' was set but 'camelCase' for the css-loader not.
-The following classes will not be available as named exports:
+The following classes will not be available as named exports for file ${filename}:
 ${skippedDefinitions.map(sd => ` - "${sd}"`).join('\n').red}
 `.yellow);
       }
+    };
+
+    if (query.namedExport && query.interface) {
+      logSkippedDefWarning();
+      cssModuleDefinition = generateCombinedInterfaceAndNamedExports(cssModuleKeys, cleanedDefinitions, filename);
+    } else if (!query.namedExport) {
+      cssModuleDefinition = generateGenericExportInterface(cssModuleKeys, filename);
+    } else {
+      logSkippedDefWarning();
+
       cssModuleDefinition = generateNamedExports(cleanedDefinitions);
     }
     persist.writeToFileIfChanged(cssModuleInterfaceFilename, cssModuleDefinition);

--- a/test/entry.ts
+++ b/test/entry.ts
@@ -4,6 +4,7 @@ import * as stylesNamedExport from './example-namedexport.css';
 import * as stylesCamelCasedNamedExport from './example-camelcase-namedexport.css';
 import './example-no-css-modules.css';
 import * as compose from './example-compose.css';
+import * as combined from './example-named-export-and-interface.css';
 
 const foo = stylesBase.foo;
 const barBaz = stylesBase['bar-baz'];
@@ -18,3 +19,5 @@ const fooCamelCaseNamedExport = stylesCamelCasedNamedExport.foo;
 const barBazCamelCaseNamedExport = stylesCamelCasedNamedExport.barBaz;
 
 const composed = compose.test;
+
+const combinedExport = combined.foo;

--- a/test/example-named-export-and-interface.css
+++ b/test/example-named-export-and-interface.css
@@ -1,0 +1,7 @@
+.foo {
+    color: white;
+}
+
+.bar-baz {
+    color: green;
+}

--- a/test/expected-example-named-export-and-interface.css.d.ts
+++ b/test/expected-example-named-export-and-interface.css.d.ts
@@ -1,6 +1,5 @@
 export interface IExampleNamedExportAndInterfaceCss {
   'foo': string;
-  'bar-baz': string;
   'barBaz': string;
 }
 

--- a/test/expected-example-named-export-and-interface.css.d.ts
+++ b/test/expected-example-named-export-and-interface.css.d.ts
@@ -1,0 +1,8 @@
+export interface IExampleNamedExportAndInterfaceCss {
+  'foo': string;
+  'bar-baz': string;
+  'barBaz': string;
+}
+
+export const foo: string;
+export const barBaz: string;

--- a/test/webpack.config.babel.js
+++ b/test/webpack.config.babel.js
@@ -12,7 +12,8 @@ module.exports = {
       { test: /example-namedexport\.css$/, loader: '../src/index.js?modules&namedExport' },
       { test: /example-camelcase-namedexport\.css$/, loader: '../src/index.js?modules&camelCase&namedExport' },
       { test: /example-no-css-modules\.css$/, loader: '../src/index.js' },
-      { test: /example-compose\.css$/, loader: '../src/index.js?modules&camelCase&namedExport' }
+      { test: /example-compose\.css$/, loader: '../src/index.js?modules&camelCase&namedExport' },
+      { test: /example-named-export-and-interface\.css$/, loader: '../src/index.js?modules&camelCase&namedExport&interface' }
     ]
   }
 };


### PR DESCRIPTION
I hit a use case where I needed both the named exports and the interface.

I need the named exports for the generated .js runtime file to work (b/c style-loader remaps exports.locals to exports).

I need the interface in order to use `keyof ICssInterface` in TypeScript, which I'm using to provide type safety around accepting an input parameter of a class name that's part of the interface.

See what you think. I'm happy to tweak based on your feedback.