### PR TITLE
Fixed bug where source maps from upstream was discarded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,10 +14,10 @@ import loggerCreator from './logger';
 
 function delegateToCssLoader(ctx, input, callback) {
   ctx.async = () => callback;
-  cssLoader.call(ctx, input);
+  cssLoader.call(ctx, ...input);
 }
 
-module.exports = function(input) {
+module.exports = function(...input) {
   if(this.cacheable) this.cacheable();
 
   // mock async step 1 - css loader is async, we need to intercept this so we get async ourselves
@@ -67,5 +67,5 @@ ${skippedDefinitions.map(sd => ` - "${sd}"`).join('\n').red}
     // mock async step 3 - make `async` return the actual callback again before calling the 'real' css-loader
     delegateToCssLoader(this, input, callback);
   };
-  cssLocalsLoader.call(this, input);
+  cssLocalsLoader.call(this, ...input);
 };


### PR DESCRIPTION
CSS-loader expects two arguments, *content* and *map*. This loader only provides CSS-loader with the first argument, which causes *map* to always be undefined. 
[Relevant source code from css-loader.](https://github.com/webpack-contrib/css-loader/blob/master/lib/loader.js#L12)

**Effect:** Previous source maps are lost.

This pull request makes sure all arguments are passed through to css-loader.

Demo of bug where sourcemaps from sass-loader are discarded: 
https://github.com/CheeseSucker/css-module-source-map-bug
