### PR TITLE
Ensure empty CSS modules export something

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,10 @@ ${skippedDefinitions.map(sd => ` - "${sd}"`).join('\n').red}
       }
       cssModuleDefinition = generateNamedExports(cleanedDefinitions);
     }
+    if (cssModuleDefinition.trim() === '') {
+      // Ensure empty CSS modules export something
+      cssModuleDefinition = 'export {};\n';
+    }
     if (query.banner) {
       // Prefix banner to CSS module
       cssModuleDefinition = query.banner + '\n' + cssModuleDefinition;


### PR DESCRIPTION
When a CSS module is considered "empty", the resulting `d.ts` file is blank.  Such modules may arise when comprising only `:global` definitions; these are styles that must be `import`ed so that Webpack may inject them into the HTML template.

TypeScript code that imports a blank type definition `d.ts` results in a compilation error:
```
error TS2306: File '${filename}.d.ts' is not a module.
```

This PR addresses this by creating an null `d.ts` export, shown below, thus avoiding the above compilation error.
```
export {};
```