### PR TITLE
Add default export to definition file

### DIFF
--- a/src/cssModuleToInterface.js
+++ b/src/cssModuleToInterface.js
@@ -95,5 +95,6 @@ ${interfaceProperties}
 }
 
 export const locals: ${interfaceName};
+export default locals;
 `);
 };


### PR DESCRIPTION
Fixes https://github.com/Jimdo/typings-for-css-modules-loader/issues/20.

When using the `style-loader`, the generated `locals` object gets invisibly murdered for unknown reasons.

If someone's _not_ using the `style-loader` they can still `import {locals}` just fine, and if they _are_ using the `style-loader` (honestly, who isn't?), they can use the default export.

This should make everyone happy, and be fully backwards-compatible.