### PR TITLE
added file path for warning output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,7 @@ module.exports = function(...input) {
         logger('warn', `Typings for CSS-Modules: option 'namedExport' was set but 'camelCase' for the css-loader not.
 The following classes will not be available as named exports:
 ${skippedDefinitions.map(sd => ` - "${sd}"`).join('\n').red}
+References were found in "${filename}".
 `.yellow);
       }
 
@@ -69,6 +70,7 @@ ${skippedDefinitions.map(sd => ` - "${sd}"`).join('\n').red}
 Consequently the following classes will not be available as named exports:
 ${reservedWordDefinitions.map(rwd => ` - "${rwd}"`).join('\n').red}
 These can be accessed using the object literal syntax; eg styles['delete'] instead of styles.delete.
+References were found in "${filename}".
 `.yellow);
       }
 


### PR DESCRIPTION
currently, when a warning message is output into the console, something like this is shown:
```
Your css contains classes which are reserved words in JavaScript.
Consequently the following classes will not be available as named exports:
 - "return"
These can be accessed using the object literal syntax; eg styles['delete'] instead of styles.delete.
```

These changes update the output to add the path to the file containing the warning so it's easier to track down where to change these references (last line):
```
Your css contains classes which are reserved words in JavaScript.
Consequently the following classes will not be available as named exports:
 - "return"
These can be accessed using the object literal syntax; eg styles['delete'] instead of styles.delete.
References were found in "/path/to/src/styles/StyleFile.scss".
```

The path is also added to the `option` output:
```
Typings for CSS-Modules: option 'namedExport' was set but 'camelCase' for the css-loader not.
The following classes will not be available as named exports:
 - "bar-baz"
References were found in "/path/to/typings-for-css-modules-loader/test/example-namedexport.css".
```